### PR TITLE
Update settings checkboxes on database change.

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -127,8 +127,9 @@ class VortaApp(QtSingleApplication):
         self.main_window.activateWindow()
 
     def toggle_main_window_visibility(self):
+        """Toggle window visibility e.g. when clicking on the tray icon."""
         if self.main_window.isVisible():
-            self.main_window.close()
+            self.main_window.hide()  # do not show 'run in background' dialog
         else:
             self.open_main_window_action()
 


### PR DESCRIPTION
This hooks to `playhouse.signals.post_save` to update the checkboxes in misc tab.

* src/vorta/views/misc_tab.py (MiscTab): Implement `update_checkbox` and `on_setting_update`.

This makes clicking the tray icon behave differently than clicking the close window decorator.
The former no longer shows the 'run in background' dialog.

* src/vorta/application.py (VortApp.toggle_main_window_visibility): Hide the main window instead of closing it.